### PR TITLE
Buy Page Created

### DIFF
--- a/lib/buy_options.dart
+++ b/lib/buy_options.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class BuyOptions extends StatelessWidget {
+  const BuyOptions({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SizedBox(height: 20),
+        Container(
+          padding: EdgeInsets.all(16.0),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                "Buy Calculation",
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 20),
+              TextFormField(
+                decoration: const InputDecoration(
+                  labelText: "Buying Price *",
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 20),
+              TextFormField(
+                decoration: const InputDecoration(
+                  labelText: "Quantity *",
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                child: ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.blue[900],
+                    padding: const EdgeInsets.symmetric(vertical: 15),
+                    textStyle: const TextStyle(fontSize: 18),
+                  ),
+                  child: const Text("Calculate"),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:sharehisab/buy_options.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -15,11 +16,56 @@ class _HomePageState extends State<HomePage> {
         appBar: AppBar(
           title: const Text(
             "Share Hisab",
-            style: TextStyle(color: Colors.white),
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
           ),
           centerTitle: true,
         ),
-        body: const Text("Hello, World!"),
+        body: SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Column(
+              children: [
+                const Text(
+                  "CALCULATION",
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    color: Colors.white,
+                  ),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 0, horizontal: 10),
+                  child: DropdownButtonFormField<String>(
+                    dropdownColor: Colors.white,
+                    value: "Buy Calculation",
+                    items: const [
+                      DropdownMenuItem(
+                        value: "Buy Calculation",
+                        child: Text("Buy Calculation"),
+                      ),
+                      DropdownMenuItem(
+                        value: "Sell Calculation",
+                        child: Text("Sell Calculation"),
+                      ),
+                    ],
+                    onChanged: (value) {},
+                  ),
+                ),
+                const BuyOptions(),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
This pull request introduces a new `BuyOptions` widget and integrates it into the `HomePage`. The changes enhance the UI by adding a calculation form and improving the styling of the `HomePage`.

### New Widget Addition:

* Added a new `BuyOptions` widget in `lib/buy_options.dart`, which includes a form for buying price and quantity inputs, and a calculate button.

### Home Page Enhancements:

* Imported the `BuyOptions` widget into `lib/home_page.dart`.
* Updated the `AppBar` title style to include bold font weight.
* Replaced the placeholder text with a scrollable column that includes a dropdown for selecting calculation type and the `BuyOptions` widget.